### PR TITLE
Implement PID slot selection for GenericMotionProfiledSubsystem (and …

### DIFF
--- a/src/main/java/frc/robot/subsystems/Arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm/Arm.java
@@ -41,8 +41,9 @@ public class Arm extends GenericMotionProfiledSubsystem<Arm.State> {
 
         private final double gortSetpoint;
         private final double bajaSetpoint;
-        
-        public double getSetpoint() {
+
+        public double getSetpoint()
+        {
             if (Constants.getRobot() == RobotType.GORT) {
                 return gortSetpoint;
             } else {
@@ -54,20 +55,20 @@ public class Arm extends GenericMotionProfiledSubsystem<Arm.State> {
     @RequiredArgsConstructor
     @Getter
     public enum State implements TargetState {
-        STOW(new ProfileType.MM_POSITION(() -> Setpoints.STOW.getSetpoint())),
-        CORAL_INTAKE(new ProfileType.MM_POSITION(() -> Setpoints.CORAL_INTAKE.getSetpoint())),
-        LEVEL_1(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_1.getSetpoint())),
-        LEVEL_2(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_2.getSetpoint())),
-        LEVEL_3(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_3.getSetpoint())),
-        LEVEL_4(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_4.getSetpoint())),
-        CLIMB(new ProfileType.MM_POSITION(() -> Setpoints.CLIMB.getSetpoint())),
-        ALGAE_LOW(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_LOW.getSetpoint())),
-        ALGAE_HIGH(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_HIGH.getSetpoint())),
-        ALGAE_GROUND(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_GROUND.getSetpoint())),
-        ALGAE_SCORE(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_SCORE.getSetpoint())),
-        BARGE(new ProfileType.MM_POSITION(() -> Setpoints.BARGE.getSetpoint())),
+        STOW(new ProfileType.MM_POSITION(() -> Setpoints.STOW.getSetpoint(), 0)),
+        CORAL_INTAKE(new ProfileType.MM_POSITION(() -> Setpoints.CORAL_INTAKE.getSetpoint(), 0)),
+        LEVEL_1(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_1.getSetpoint(), 0)),
+        LEVEL_2(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_2.getSetpoint(), 0)),
+        LEVEL_3(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_3.getSetpoint(), 0)),
+        LEVEL_4(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_4.getSetpoint(), 0)),
+        CLIMB(new ProfileType.MM_POSITION(() -> Setpoints.CLIMB.getSetpoint(), 0)),
+        ALGAE_LOW(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_LOW.getSetpoint(), 0)),
+        ALGAE_HIGH(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_HIGH.getSetpoint(), 0)),
+        ALGAE_GROUND(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_GROUND.getSetpoint(), 0)),
+        ALGAE_SCORE(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_SCORE.getSetpoint(), 0)),
+        BARGE(new ProfileType.MM_POSITION(() -> Setpoints.BARGE.getSetpoint(), 0)),
         TUNING(new ProfileType.MM_POSITION(
-            () -> Units.degreesToRotations(positionTuning.getAsDouble()))),
+            () -> Units.degreesToRotations(positionTuning.getAsDouble()), 0)),
         CHARACTERIZATION(new ProfileType.CHARACTERIZATION()),
         COAST(new ProfileType.DISABLED_COAST()),
         BRAKE(new ProfileType.DISABLED_BRAKE());

--- a/src/main/java/frc/robot/subsystems/Claw/ClawRoller/ClawRoller.java
+++ b/src/main/java/frc/robot/subsystems/Claw/ClawRoller/ClawRoller.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.Claw.ClawRoller;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.subsystems.GenericMotionProfiledSubsystem.GenericMotionProfiledSubsystem;
 import frc.robot.subsystems.GenericMotionProfiledSubsystem.GenericMotionProfiledSubsystem.TargetState;
@@ -24,7 +23,7 @@ public class ClawRoller
         EJECT(new ProfileType.OPEN_VOLTAGE(() -> 10.0)),
         SCORE(new ProfileType.OPEN_VOLTAGE(() -> 4.0)),
         SCORE_L1(new ProfileType.OPEN_VOLTAGE(() -> 1.5)),
-        SHUFFLE(new ProfileType.VELOCITY(() -> -1)),
+        SHUFFLE(new ProfileType.VELOCITY(() -> -1, 0)),
         HOLDCORAL(new ProfileType.DISABLED_BRAKE()),
         ALGAE_INTAKE(new ProfileType.OPEN_CURRENT(() -> -90, () -> 0.6));
 

--- a/src/main/java/frc/robot/subsystems/Claw/ClawRoller/ClawRollerConstants.java
+++ b/src/main/java/frc/robot/subsystems/Claw/ClawRoller/ClawRollerConstants.java
@@ -52,6 +52,13 @@ public final class ClawRollerConstants {
         kSubSysConstants.kMotorConfig.MotionMagic.MotionMagicCruiseVelocity = 100;
         kSubSysConstants.kMotorConfig.MotionMagic.MotionMagicAcceleration = 10;
         kSubSysConstants.kMotorConfig.MotionMagic.MotionMagicJerk = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kP = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kI = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kD = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kG = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kS = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kV = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kA = 0;
 
         /* SIM system profile constants */
         kSubSysConstants.kSimMotorConfig.Slot0.kP = 500;

--- a/src/main/java/frc/robot/subsystems/Climber/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber/Climber.java
@@ -1,9 +1,7 @@
 package frc.robot.subsystems.Climber;
 
-import java.util.function.DoubleSupplier;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -30,10 +28,10 @@ public class Climber extends GenericMotionProfiledSubsystem<Climber.State> {
     public enum State implements TargetState {
         // HOME is climber upright, Prep - Assuming that PREP position is parallel to the x axis,
         // CLIMB is inwards
-        HOME(new ProfileType.MM_POSITION(() -> 0)),
-        PREP(new ProfileType.MM_POSITION(() -> -185)),
-        CLIMB(new ProfileType.MM_POSITION(() -> 15)),
-        ClIMB_MORE(new ProfileType.MM_POSITION(() -> 20)),
+        HOME(new ProfileType.MM_POSITION(() -> 0, 0)),
+        PREP(new ProfileType.MM_POSITION(() -> -185, 0)),
+        CLIMB(new ProfileType.MM_POSITION(() -> 15, 0)),
+        ClIMB_MORE(new ProfileType.MM_POSITION(() -> 20, 0)),
         HOMING(new ProfileType.OPEN_VOLTAGE(() -> 3));
 
         private final ProfileType profileType;

--- a/src/main/java/frc/robot/subsystems/Elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator/Elevator.java
@@ -46,8 +46,9 @@ public class Elevator extends GenericMotionProfiledSubsystem<Elevator.State> {
 
         private final double gortSetpoint;
         private final double bajaSetpoint;
-        
-        public double getSetpoint() {
+
+        public double getSetpoint()
+        {
             if (Constants.getRobot() == RobotType.GORT) {
                 return gortSetpoint;
             } else {
@@ -60,19 +61,19 @@ public class Elevator extends GenericMotionProfiledSubsystem<Elevator.State> {
     @Getter
     public enum State implements TargetState {
         HOMING(new ProfileType.OPEN_VOLTAGE(() -> homingTuning.getAsDouble())),
-        STOW(new ProfileType.MM_POSITION(() -> Setpoints.STOW.getSetpoint())),
-        CORAL_INTAKE(new ProfileType.MM_POSITION(() -> Setpoints.CORAL_INTAKE.getSetpoint())),
-        LEVEL_1(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_1.getSetpoint())),
-        LEVEL_2(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_2.getSetpoint())),
-        LEVEL_3(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_3.getSetpoint())),
-        LEVEL_4(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_4.getSetpoint())),
-        CLIMB(new ProfileType.MM_POSITION(() -> Setpoints.CLIMB.getSetpoint())),
-        ALGAE_LOW(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_LOW.getSetpoint())),
-        ALGAE_HIGH(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_HIGH.getSetpoint())),
-        ALGAE_GROUND(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_GROUND.getSetpoint())),
-        ALGAE_SCORE(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_SCORE.getSetpoint())),
-        BARGE(new ProfileType.MM_POSITION(() -> Setpoints.BARGE.getSetpoint())),
-        TUNING(new ProfileType.MM_POSITION(() -> positionTuning.getAsDouble())),
+        STOW(new ProfileType.MM_POSITION(() -> Setpoints.STOW.getSetpoint(), 0)),
+        CORAL_INTAKE(new ProfileType.MM_POSITION(() -> Setpoints.CORAL_INTAKE.getSetpoint(), 0)),
+        LEVEL_1(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_1.getSetpoint(), 0)),
+        LEVEL_2(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_2.getSetpoint(), 0)),
+        LEVEL_3(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_3.getSetpoint(), 0)),
+        LEVEL_4(new ProfileType.MM_POSITION(() -> Setpoints.LEVEL_4.getSetpoint(), 0)),
+        CLIMB(new ProfileType.MM_POSITION(() -> Setpoints.CLIMB.getSetpoint(), 0)),
+        ALGAE_LOW(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_LOW.getSetpoint(), 0)),
+        ALGAE_HIGH(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_HIGH.getSetpoint(), 0)),
+        ALGAE_GROUND(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_GROUND.getSetpoint(), 0)),
+        ALGAE_SCORE(new ProfileType.MM_POSITION(() -> Setpoints.ALGAE_SCORE.getSetpoint(), 0)),
+        BARGE(new ProfileType.MM_POSITION(() -> Setpoints.BARGE.getSetpoint(), 0)),
+        TUNING(new ProfileType.MM_POSITION(() -> positionTuning.getAsDouble(), 0)),
         CHARACTERIZATION(new ProfileType.CHARACTERIZATION()),
         COAST(new ProfileType.DISABLED_COAST()),
         BRAKE(new ProfileType.DISABLED_BRAKE());

--- a/src/main/java/frc/robot/subsystems/Elevator/ElevatorConstants.java
+++ b/src/main/java/frc/robot/subsystems/Elevator/ElevatorConstants.java
@@ -85,6 +85,14 @@ public final class ElevatorConstants {
         kSubSysConstants.kMotorConfig.MotionMagic.MotionMagicCruiseVelocity = 400;
         kSubSysConstants.kMotorConfig.MotionMagic.MotionMagicAcceleration = 40;
         kSubSysConstants.kMotorConfig.MotionMagic.MotionMagicJerk = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kP = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kI = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kD = 0;
+        kSubSysConstants.kMotorConfig.Slot1.GravityType = GravityTypeValue.Elevator_Static;
+        kSubSysConstants.kMotorConfig.Slot1.kG = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kS = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kV = 0;
+        kSubSysConstants.kMotorConfig.Slot1.kA = 0;
 
         /* SIM system profile constants */
         kSubSysConstants.kSimMotorConfig.Slot0.kP = 300.0;

--- a/src/main/java/frc/robot/subsystems/GenericMotionProfiledSubsystem/GenericMotionProfiledSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/GenericMotionProfiledSubsystem/GenericMotionProfiledSubsystem.java
@@ -16,13 +16,13 @@ public abstract class GenericMotionProfiledSubsystem<G extends GenericMotionProf
     private LoggedTunableNumber kP, kI, kD, kG, kS, kV, kA, kCruiseVelocity, kAcceleration, kJerk;
 
     public sealed interface ProfileType {
-        record POSITION(DoubleSupplier position) implements ProfileType {
+        record POSITION(DoubleSupplier position, int slot) implements ProfileType {
         }
-        record VELOCITY(DoubleSupplier velocity) implements ProfileType {
+        record VELOCITY(DoubleSupplier velocity, int slot) implements ProfileType {
         }
-        record MM_POSITION(DoubleSupplier position) implements ProfileType {
+        record MM_POSITION(DoubleSupplier position, int slot) implements ProfileType {
         }
-        record MM_VELOCITY(DoubleSupplier velocity) implements ProfileType {
+        record MM_VELOCITY(DoubleSupplier velocity, int slot) implements ProfileType {
         }
         record OPEN_VOLTAGE(DoubleSupplier voltage) implements ProfileType {
         }
@@ -144,19 +144,19 @@ public abstract class GenericMotionProfiledSubsystem<G extends GenericMotionProf
         if (m_proType instanceof ProfileType.POSITION) {
             /* Run Closed Loop to position in rotations */
             ProfileType.POSITION proType = (ProfileType.POSITION) m_proType;
-            io.runToPosition(proType.position.getAsDouble());
+            io.runToPosition(proType.position.getAsDouble(), proType.slot);
         } else if (m_proType instanceof ProfileType.VELOCITY) {
             /* Run Closed Loop to velocity in rotations/second */
             ProfileType.VELOCITY proType = (ProfileType.VELOCITY) m_proType;
-            io.runToVelocity(proType.velocity.getAsDouble());
+            io.runToVelocity(proType.velocity.getAsDouble(), proType.slot);
         } else if (m_proType instanceof ProfileType.MM_POSITION) {
             /* Run Motion Magic to the specified position setpoint (in rotations) */
             ProfileType.MM_POSITION proType = (ProfileType.MM_POSITION) m_proType;
-            io.runMotionMagicPosition(proType.position.getAsDouble());
+            io.runMotionMagicPosition(proType.position.getAsDouble(), proType.slot);
         } else if (m_proType instanceof ProfileType.MM_VELOCITY) {
             /* Run Motion Magic to the specified velocity setpoint (in rotations/second) */
             ProfileType.MM_VELOCITY proType = (ProfileType.MM_VELOCITY) m_proType;
-            io.runMotionMagicVelocity(proType.velocity.getAsDouble());
+            io.runMotionMagicVelocity(proType.velocity.getAsDouble(), proType.slot);
         } else if (m_proType instanceof ProfileType.OPEN_VOLTAGE) {
             /* Run Open Loop using specified voltage in volts */
             ProfileType.OPEN_VOLTAGE proType = (ProfileType.OPEN_VOLTAGE) m_proType;

--- a/src/main/java/frc/robot/subsystems/GenericMotionProfiledSubsystem/GenericMotionProfiledSubsystemIO.java
+++ b/src/main/java/frc/robot/subsystems/GenericMotionProfiledSubsystem/GenericMotionProfiledSubsystemIO.java
@@ -39,19 +39,19 @@ public interface GenericMotionProfiledSubsystemIO {
     {}
 
     /** Run Closed Loop to position in rotations */
-    public default void runToPosition(double position)
+    public default void runToPosition(double position, int slot)
     {}
 
     /** Run Closed Loop to velocity in rotations/second */
-    public default void runToVelocity(double velocity)
+    public default void runToVelocity(double velocity, int slot)
     {}
 
     /** Run Motion Magic to the specified setpoint */
-    public default void runMotionMagicPosition(double setpoint)
+    public default void runMotionMagicPosition(double setpoint, int slot)
     {}
 
     /** Run Motion Magic to the specified velocity */
-    public default void runMotionMagicVelocity(double velocity)
+    public default void runMotionMagicVelocity(double velocity, int slot)
     {}
 
     /* Stop in Coast mode */

--- a/src/main/java/frc/robot/subsystems/GenericMotionProfiledSubsystem/GenericMotionProfiledSubsystemIOImpl.java
+++ b/src/main/java/frc/robot/subsystems/GenericMotionProfiledSubsystem/GenericMotionProfiledSubsystemIOImpl.java
@@ -26,7 +26,6 @@ import frc.robot.util.drivers.Phoenix6Util;
 import frc.robot.util.sim.PhysicsSim;
 import java.util.ArrayList;
 import java.util.List;
-import org.littletonrobotics.junction.Logger;
 
 /**
  * Generic motion IO implementation for any motion mechanism using a TalonFX motor controller, an
@@ -84,13 +83,13 @@ public class GenericMotionProfiledSubsystemIOImpl implements GenericMotionProfil
         new VoltageOut(0.0).withEnableFOC(true).withUpdateFreqHz(0.0);
     private final TorqueCurrentFOC currentControl = new TorqueCurrentFOC(0.0).withUpdateFreqHz(0.0);
     private final PositionTorqueCurrentFOC positionControl =
-        new PositionTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0).withSlot(0);
+        new PositionTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0);
     private final VelocityTorqueCurrentFOC velocityControl =
-        new VelocityTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0).withSlot(0);
+        new VelocityTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0);
     private final MotionMagicTorqueCurrentFOC motionMagicPositionControl =
-        new MotionMagicTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0).withSlot(0);
+        new MotionMagicTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0);
     private final MotionMagicVelocityTorqueCurrentFOC motionMagicVelocityControl =
-        new MotionMagicVelocityTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0).withSlot(0);
+        new MotionMagicVelocityTorqueCurrentFOC(0.0).withUpdateFreqHz(0.0);
     private final CoastOut coastOut = new CoastOut();
     private final StaticBrake staticBrake = new StaticBrake();
 
@@ -354,35 +353,35 @@ public class GenericMotionProfiledSubsystemIOImpl implements GenericMotionProfil
 
     /** Run Closed Loop to setpoint in rotations */
     @Override
-    public void runToPosition(double position)
+    public void runToPosition(double position, int slot)
     {
-        mMainMotor.setControl(positionControl.withPosition(position));
+        mMainMotor.setControl(positionControl.withPosition(position).withSlot(slot));
         mOpSetpoint = position;
     }
 
     /** Run Closed Loop to velocity in rotations/second */
     @Override
-    public void runToVelocity(double velocity)
+    public void runToVelocity(double velocity, int slot)
     {
-        mMainMotor.setControl(velocityControl.withVelocity(velocity));
+        mMainMotor.setControl(velocityControl.withVelocity(velocity).withSlot(slot));
         mOpSetpoint = velocity;
     }
 
     /** Run Motion Magic to the specified setpoint */
     @Override
-    public void runMotionMagicPosition(double setpoint)
+    public void runMotionMagicPosition(double setpoint, int slot)
     {
         mMainMotor.setControl(
-            motionMagicPositionControl.withPosition(setpoint));
+            motionMagicPositionControl.withPosition(setpoint).withSlot(slot));
         mOpSetpoint = setpoint;
     }
 
     /** Run Motion Magic Velocity to the specified velocity */
     @Override
-    public void runMotionMagicVelocity(double velocity)
+    public void runMotionMagicVelocity(double velocity, int slot)
     {
         mMainMotor.setControl(
-            motionMagicVelocityControl.withVelocity(velocity));
+            motionMagicVelocityControl.withVelocity(velocity).withSlot(slot));
     }
 
     /* Stop in Coast mode */


### PR DESCRIPTION
…subclasses)
- Slot selection is only supported for Closed-Loop profiles
- Define additional Slot parameters in the appropriate Constants file (see Elevator or Claw Constants for examples)
- Specify Slot # in the enumerated State definitions in the top-level subsystem class (Elevator, Arm, ClawRoller, etc)

**Caveats:**
- MotionMagic constants (cruise velocity, etc.) do not have slots, so you are still limited to only one set.
- The LoggedTuneableNumbers still work only on Slot 0, so if you want to use them for real-time tuning, you can only tune Slot 0. Afterwards, you can move the constants to another slot, or just use PhoenixTuner.
- Slot numbers are limited to 0, 1, and 2.